### PR TITLE
Fix incorrect grepping for partition

### DIFF
--- a/find-best-partition
+++ b/find-best-partition
@@ -93,7 +93,7 @@ if [[ $optU = check ]]; then
   lineN=$(grep -n " -p "  $submissionScript | cut -d':' -f1)
 
   if [ ! $lineN ]; then
-    lineN=$(grep -n " --partition "  $submissionScript | cut -d':' -f1)
+    lineN=$(grep -n " --partition"  $submissionScript | cut -d':' -f1)
     if [ ! $lineN ]; then
       echo "   --- Error: Specifiy a default partition in Slurm submission script."
       exit 1


### PR DESCRIPTION
When I used the following line in my SLURM script, find-best-partition failed to run, even though the SBATCH script is valid and runs w/ SBATCH
```#SBATCH --partition=kempner```

I deleted a single space so that this line does not cause the script to
fail the check